### PR TITLE
Handles concurrent attempt to connect also well for load balancing.

### DIFF
--- a/jdbc-yugabytedb/src/main/java/com/yugabyte/ysql/ClusterAwareLoadBalancer.java
+++ b/jdbc-yugabytedb/src/main/java/com/yugabyte/ysql/ClusterAwareLoadBalancer.java
@@ -39,23 +39,23 @@ public class ClusterAwareLoadBalancer {
 
   public String getLeastLoadedServer(List<String> failedHosts) {
     int min = Integer.MAX_VALUE;
-    ArrayList<String> minHostList = new ArrayList<>();
+    ArrayList<String> minConnectionsHostList = new ArrayList<>();
     for (String h : hostToNumConnMap.keySet()) {
       if (failedHosts.contains(h)) continue;
       int currLoad = hostToNumConnMap.get(h);
       if (currLoad < min) {
         min = currLoad;
-        minHostList.clear();
-        minHostList.add(h);
+        minConnectionsHostList.clear();
+        minConnectionsHostList.add(h);
       } else if (currLoad == min) {
-        minHostList.add(h);
+        minConnectionsHostList.add(h);
       }
     }
     // Choose a random from the minimum list
     String chosenHost = null;
-    if (minHostList.size() > 0) {
+    if (minConnectionsHostList.size() > 0) {
       Random rand = new Random();
-      chosenHost = minHostList.get(rand.nextInt(minHostList.size()));
+      chosenHost = minConnectionsHostList.get(rand.nextInt(minConnectionsHostList.size()));
     }
     LOGGER.log(Level.INFO, "Host chosen for new connection: " + chosenHost);
     return chosenHost;

--- a/jdbc-yugabytedb/src/main/java/com/yugabyte/ysql/ClusterAwareLoadBalancer.java
+++ b/jdbc-yugabytedb/src/main/java/com/yugabyte/ysql/ClusterAwareLoadBalancer.java
@@ -38,16 +38,26 @@ public class ClusterAwareLoadBalancer {
   }
 
   public String getLeastLoadedServer(List<String> failedHosts) {
-    String chosenHost = null;
     int min = Integer.MAX_VALUE;
+    ArrayList<String> minHostList = new ArrayList<>();
     for (String h : hostToNumConnMap.keySet()) {
       if (failedHosts.contains(h)) continue;
       int currLoad = hostToNumConnMap.get(h);
       if (currLoad < min) {
-        chosenHost = h;
         min = currLoad;
+        minHostList.clear();
+        minHostList.add(h);
+      } else if (currLoad == min) {
+        minHostList.add(h);
       }
     }
+    // Choose a random from the minimum list
+    String chosenHost = null;
+    if (minHostList.size() > 0) {
+      Random rand = new Random();
+      chosenHost = minHostList.get(rand.nextInt(minHostList.size()));
+    }
+    LOGGER.log(Level.INFO, "Host chosen for new connection: " + chosenHost);
     return chosenHost;
   }
 
@@ -67,7 +77,7 @@ public class ClusterAwareLoadBalancer {
 
   protected ArrayList<String> getCurrentServers(Connection conn) throws SQLException {
     Statement st = conn.createStatement();
-    LOGGER.log(Level.FINE, "Getting the list of servers");
+    LOGGER.log(Level.INFO, "Getting the list of servers");
     ResultSet rs = st.executeQuery(GET_SERVERS_QUERY);
     ArrayList<String> currentPrivateIps = new ArrayList<>();
     ArrayList<String> currentPublicIps = new ArrayList<>();
@@ -97,7 +107,7 @@ public class ClusterAwareLoadBalancer {
       return null;
     }
     ArrayList<String> currentHosts = useHostColumn ? privateHosts : publicHosts;
-    LOGGER.log(Level.FINE, "List of servers got {0}", currentHosts);
+    LOGGER.log(Level.INFO, "List of servers got {0}", currentHosts);
     return currentHosts;
   }
 

--- a/jdbc-yugabytedb/src/main/java/org/postgresql/Driver.java
+++ b/jdbc-yugabytedb/src/main/java/org/postgresql/Driver.java
@@ -486,7 +486,7 @@ public class Driver implements java.sql.Driver {
         hspec, user(lbprops.getOriginalProperties()),
           database(lbprops.getOriginalProperties()), props, url);
       try {
-        LOGGER.log(Level.FINE, "refreshing server list from {0}", hspec[0].getHost());
+        LOGGER.log(Level.INFO, "refreshing server list from {0}", hspec[0].getHost());
         if (!loadBalancer.refresh(controlConnection)) {
           return null;
         }
@@ -711,6 +711,15 @@ public class Driver implements java.sql.Driver {
       }
     }
 
+    // Check for new load balance properties
+    if (defaults != null) {
+      if (defaults.containsKey("load-balance")) {
+        urlProps.setProperty("load-balance", defaults.getProperty("load-balance"));
+      }
+      if (defaults.containsKey("topology-keys")) {
+        urlProps.setProperty("topology-keys", defaults.getProperty("topology-keys"));
+      }
+    }
     return urlProps;
   }
 


### PR DESCRIPTION
In cases where connection attempts from a large number of threads will happen concurrently then the load balancing logic was not doing a great job leading to a skew. This change fixes it.
It also fixes the new property 'load-balance' and 'topology-keys' being passed in property bag. There was an issue there where it was getting ignored. 
