### PR TITLE
Fix for issue 9720 and 9718

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -11,7 +11,7 @@
     <dependency>
       <groupId>com.yugabyte</groupId>
       <artifactId>jdbc-yugabytedb</artifactId>
-      <version>42.2.7-yb-5-beta.2</version>
+      <version>42.2.7-yb-6-SNAPSHOT</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/com.zaxxer/HikariCP -->

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -11,7 +11,7 @@
     <dependency>
       <groupId>com.yugabyte</groupId>
       <artifactId>jdbc-yugabytedb</artifactId>
-      <version>42.2.7-yb-6-SNAPSHOT</version>
+      <version>42.2.7-yb-5-beta.2</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/com.zaxxer/HikariCP -->

--- a/jdbc-yugabytedb/src/main/java/com/yugabyte/ysql/ClusterAwareLoadBalancer.java
+++ b/jdbc-yugabytedb/src/main/java/com/yugabyte/ysql/ClusterAwareLoadBalancer.java
@@ -95,23 +95,21 @@ public class ClusterAwareLoadBalancer {
     ArrayList<String> currentPublicIps = new ArrayList<>();
     String hostConnectedTo = ((PgConnection)conn).getQueryExecutor().getHostSpec().getHost();
     InetAddress hostConnectedInetAddr;
-    try {
-      hostConnectedInetAddr = InetAddress.getByName(hostConnectedTo);
-    } catch (UnknownHostException e) {
-      throw new SQLException();
-    }
+
     Boolean useHostColumn = null;
     boolean isIpv6Addresses = hostConnectedTo.contains(":");
     if (isIpv6Addresses) {
       hostConnectedTo = hostConnectedTo.replace("[", "").replace("]", "");
-      try {
-        hostConnectedInetAddr = InetAddress.getByName(hostConnectedTo);
-      } catch (UnknownHostException e) {
-        // This is totally unexpected. As the connection is already created on this host
-        throw new PSQLException(GT.tr("Unexpected UnknownHostException for ${0} ", hostConnectedTo),
-          PSQLState.UNKNOWN_STATE, e);
-      }
     }
+
+    try {
+      hostConnectedInetAddr = InetAddress.getByName(hostConnectedTo);
+    } catch (UnknownHostException e) {
+      // This is totally unexpected. As the connection is already created on this host
+      throw new PSQLException(GT.tr("Unexpected UnknownHostException for ${0} ", hostConnectedTo),
+        PSQLState.UNKNOWN_STATE, e);
+    }
+
     while (rs.next()) {
       String host = rs.getString("host");
       String public_host = rs.getString("public_ip");

--- a/jdbc-yugabytedb/src/main/java/com/yugabyte/ysql/ClusterAwareLoadBalancer.java
+++ b/jdbc-yugabytedb/src/main/java/com/yugabyte/ysql/ClusterAwareLoadBalancer.java
@@ -1,7 +1,12 @@
 package com.yugabyte.ysql;
 
 import org.postgresql.jdbc.PgConnection;
+import org.postgresql.util.GT;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.sql.*;
 import java.util.*;
 import java.util.logging.Level;
@@ -89,10 +94,23 @@ public class ClusterAwareLoadBalancer {
     ArrayList<String> currentPrivateIps = new ArrayList<>();
     ArrayList<String> currentPublicIps = new ArrayList<>();
     String hostConnectedTo = ((PgConnection)conn).getQueryExecutor().getHostSpec().getHost();
+    InetAddress hostConnectedInetAddr;
+    try {
+      hostConnectedInetAddr = InetAddress.getByName(hostConnectedTo);
+    } catch (UnknownHostException e) {
+      throw new SQLException();
+    }
     Boolean useHostColumn = null;
     boolean isIpv6Addresses = hostConnectedTo.contains(":");
     if (isIpv6Addresses) {
       hostConnectedTo = hostConnectedTo.replace("[", "").replace("]", "");
+      try {
+        hostConnectedInetAddr = InetAddress.getByName(hostConnectedTo);
+      } catch (UnknownHostException e) {
+        // This is totally unexpected. As the connection is already created on this host
+        throw new PSQLException(GT.tr("Unexpected UnknownHostException for ${0} ", hostConnectedTo),
+          PSQLState.UNKNOWN_STATE, e);
+      }
     }
     while (rs.next()) {
       String host = rs.getString("host");
@@ -102,16 +120,35 @@ public class ClusterAwareLoadBalancer {
       hostPortMap_public.put(public_host, port);
       currentPrivateIps.add(host);
       currentPublicIps.add(public_host);
-      if (hostConnectedTo.equals(host)) {
-        useHostColumn = Boolean.TRUE;
-      } else if (hostConnectedTo.equals(public_host)) {
-        useHostColumn = Boolean.FALSE;
+      InetAddress hostInetAddr;
+      InetAddress publicHostInetAddr;
+      try {
+        hostInetAddr = (host != null
+          && !host.isEmpty()) ? InetAddress.getByName(host) : null;
+      } catch (UnknownHostException e) {
+        // set the hostInet to null
+        hostInetAddr = null;
+      }
+      try {
+        publicHostInetAddr = (public_host != null
+          && !public_host.isEmpty()) ? InetAddress.getByName(public_host) : null;
+      } catch (UnknownHostException e) {
+        // set the publicHostInetAddr to null
+        publicHostInetAddr = null;
+      }
+      if (useHostColumn == null) {
+        if (hostConnectedInetAddr.equals(hostInetAddr)) {
+          useHostColumn = Boolean.TRUE;
+        } else if (hostConnectedInetAddr.equals(publicHostInetAddr)) {
+          useHostColumn = Boolean.FALSE;
+        }
       }
     }
     return getPrivateOrPublicServers(useHostColumn, currentPrivateIps, currentPublicIps);
   }
 
-  protected ArrayList<String> getPrivateOrPublicServers(Boolean useHostColumn, ArrayList<String> privateHosts, ArrayList<String> publicHosts) {
+  protected ArrayList<String> getPrivateOrPublicServers(
+    Boolean useHostColumn, ArrayList<String> privateHosts, ArrayList<String> publicHosts) {
     if (useHostColumn == null) {
       LOGGER.log(Level.WARNING, "Either private or public should have been determined");
       return null;

--- a/jdbc-yugabytedb/src/main/java/com/yugabyte/ysql/ClusterAwareLoadBalancer.java
+++ b/jdbc-yugabytedb/src/main/java/com/yugabyte/ysql/ClusterAwareLoadBalancer.java
@@ -121,15 +121,14 @@ public class ClusterAwareLoadBalancer {
       InetAddress hostInetAddr;
       InetAddress publicHostInetAddr;
       try {
-        hostInetAddr = (host != null
-          && !host.isEmpty()) ? InetAddress.getByName(host) : null;
+        hostInetAddr = InetAddress.getByName(host);
       } catch (UnknownHostException e) {
         // set the hostInet to null
         hostInetAddr = null;
       }
       try {
-        publicHostInetAddr = (public_host != null
-          && !public_host.isEmpty()) ? InetAddress.getByName(public_host) : null;
+        publicHostInetAddr = !public_host.isEmpty()
+          ? InetAddress.getByName(public_host) : null;
       } catch (UnknownHostException e) {
         // set the publicHostInetAddr to null
         publicHostInetAddr = null;

--- a/jdbc-yugabytedb/src/main/java/com/yugabyte/ysql/LoadBalanceProperties.java
+++ b/jdbc-yugabytedb/src/main/java/com/yugabyte/ysql/LoadBalanceProperties.java
@@ -3,6 +3,7 @@ package com.yugabyte.ysql;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class LoadBalanceProperties {
@@ -47,12 +48,20 @@ public class LoadBalanceProperties {
       }
       if (part.startsWith(load_balancer_key)) {
         String[] lb_parts = part.split(EQUALS);
+        if (lb_parts.length < 2) {
+          LOGGER.log(Level.WARNING, "No value provided for load balance property. Ignoring it.");
+          continue;
+        }
         String propValue = lb_parts[1];
         if (propValue.equalsIgnoreCase("true")) {
           this.hasLoadBalance = true;
         }
       } else if (part.startsWith(topology_key)) {
         String[] lb_parts = part.split(EQUALS);
+        if (lb_parts.length < 2) {
+          LOGGER.log(Level.WARNING, "No value provided for topology keys. Ignoring it.");
+          continue;
+        }
         placements = lb_parts[1];
       } else {
         sb.append('&');

--- a/jdbc-yugabytedb/src/main/java/org/postgresql/Driver.java
+++ b/jdbc-yugabytedb/src/main/java/org/postgresql/Driver.java
@@ -463,10 +463,10 @@ public class Driver implements java.sql.Driver {
         return conn;
       }
       LOGGER.log(Level.WARNING, "Failed to apply load balance. Trying normal connection");
-      // but remember to use stripped url and props
-      url = lbprops.getStrippedURL();
-      properties = lbprops.getStrippedProperties();
     }
+    // Cleanup extra properties used for load balancing
+    url = lbprops.getStrippedURL();
+    properties = lbprops.getStrippedProperties();
     return new PgConnection(hostSpecs(properties), user(properties), database(properties), properties, url);
   }
 


### PR DESCRIPTION
GH-9720 - The new load balancer code was doing a direct string match for determining two same hosts. This is not right specially for localhost and loopback addresses. Therefore this change is doing InetAddress equals now.

GH-9718 - The load balancer code while processing the new load balance properties like 'topology-keys' and 'load-balance' properties was not handling malformed url with empty values therefore the exception. Now the new behaviour is to log a warning and then fallback to original behaviour which connects to the database without using the new load balance behaviour.   

### All Submissions:

* [✅] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [✅] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [✅] Does your submission pass tests?
2. [✅] Does mvn checkstyle:check pass ?
3. [ ] Have you added your new test classes to an existing test suite?

### Changes to Existing Features:

* [✅] Does this break existing behaviour? If so please explain.
* [✅] Have you added an explanation of what your changes do and why you'd like us to include them?
* [✅] Have you written new tests for your core changes, as applicable?
* [✅] Have you successfully run tests with your changes locally?
