### PR TITLE
Fix for github issue: https://github.com/yugabyte/yugabyte-db/issues/9764

### DIFF
--- a/jdbc-yugabytedb/src/main/java/org/postgresql/Driver.java
+++ b/jdbc-yugabytedb/src/main/java/org/postgresql/Driver.java
@@ -517,7 +517,7 @@ public class Driver implements java.sql.Driver {
         newConnection.setLoadBalancer(loadBalancer);
         if (!loadBalancer.refresh(newConnection)) {
           // There seems to be a problem with the current chosen host as well.
-          // Close the connection and return null
+          // Close the connection and try next
           LOGGER.log(Level.WARNING, "yb_servers() refresh returned no servers");
           loadBalancer.updateConnectionMap(chosenHost, -1);
           failedHosts.add(chosenHost);


### PR DESCRIPTION
Not relying on random function to select least loaded server by concurrent
threads. Instead putting a small synch block to just quickly determine the least,
optimistically increment the connection counter assuming connection will
be successful. However if connection fails then decrementing the
reference count or removing it from the internal 'host->conn' map

### All Submissions:

* [✅] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [✅] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [✅] Does your submission pass tests?
2. [ ] Does mvn checkstyle:check pass ?
3. [ ] Have you added your new test classes to an existing test suite? - Tested with existing yb_sample_apps Sqlnserts workload

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [✅] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [✅] Have you successfully run tests with your changes locally?
