### PR TITLE
Addresses github issue #9896

### DIFF
--- a/examples/run.sh
+++ b/examples/run.sh
@@ -10,28 +10,33 @@ verbosePrint() {
 
 usage() {
           echo
-          echo "Usage: $0 [-v] [-i] [-h] -D <path/to/yugabyte/installation/>" 1>&2;
+          echo "Usage: $0 [-v] [-i] [-h] [-d] -D <path_to_yugabyte_installation>" 1>&2;
           echo 
           echo "-v - Run in verbose mode"
           echo "-i - Run in interactive mode"
           echo "-h - Print the help for this script"
           echo "-D - The installation directory of YugabyteDB"
+          echo "-d - Set log-level to 'debug' for driver"
           echo
           exit 1;
         }              
 
-VERBOSE=0                                                 
+VERBOSE=0
+DEBUG=0
 INTERACTIVE=0                                               
 INSTALL_DIR=""
 
-while getopts ":vihD:" o; do                                        
+while getopts ":vihdD:" o; do
   case "$o" in                                             
     v)                                                 
       VERBOSE=1                                           
       ;;                                               
     i)                                                 
       INTERACTIVE=1                                         
-      ;;                                               
+      ;;
+    d)
+      DEBUG=1
+      ;;
     h)                                                 
       usage
       ;;                                               
@@ -69,11 +74,11 @@ echo ""
 case $choice in
   1)
     verbosePrint $VERBOSE "starting the uniform_load_balance_run.sh script"
-    ./uniform_load_balance_run.sh $VERBOSE $INTERACTIVE $INSTALL_DIR
+    ./uniform_load_balance_run.sh $VERBOSE $INTERACTIVE $DEBUG $INSTALL_DIR
     ;;
   2) 
     verbosePrint $VERBOSE "starting the topology_aware_load_balance_run.sh script"
-    ./topology_aware_load_balance_run.sh $VERBOSE $INTERACTIVE $INSTALL_DIR
+    ./topology_aware_load_balance_run.sh $VERBOSE $INTERACTIVE $DEBUG $INSTALL_DIR
     ;;
   *)
     echo "INVALID OPTION"

--- a/examples/src/main/java/com/yugabyte/examples/TopologyAwareLoadBalanceExample.java
+++ b/examples/src/main/java/com/yugabyte/examples/TopologyAwareLoadBalanceExample.java
@@ -16,6 +16,7 @@ public class TopologyAwareLoadBalanceExample extends UniformLoadBalanceExample{
     int argsLen = args.length;
     Boolean verbose = argsLen > 0 ? args[0].equals("1") : Boolean.FALSE;
     Boolean interactive = argsLen > 1 ? args[1].equals("1") : Boolean.FALSE;
+    debugLogging = argsLen > 2 ? args[2].equals("1") : Boolean.FALSE;
     // Since it is just a demo app. Using some smaller values so that it can run
     // on laptop
     String numConnections = "6";
@@ -23,11 +24,15 @@ public class TopologyAwareLoadBalanceExample extends UniformLoadBalanceExample{
     String controlPort = "5433";
 
     controlUrl = "jdbc:postgresql://" + controlHost
-      + ":" + controlPort + "/yugabyte?user=yugabyte&password=yugabyte&load-balance=true&topology-keys=region1.zone1";
-
+      + ":" + controlPort + "/yugabyte?user=yugabyte&password=yugabyte&load-balance=true&topology-keys=cloud1.region1.zone1";
+    if (debugLogging) {
+      controlUrl = "jdbc:postgresql://" + controlHost
+        + ":" + controlPort + "/yugabyte?user=yugabyte&password=yugabyte&load-balance=true"
+        + "&topology-keys=cloud1.region1.zone1&loggerLevel=debug";
+    }
     System.out.println("Setting up the connection pool having 6 connections.......");
 
-    testUsingHikariPool("topology_aware_load_balance", "region1.zone1", "region1.zone1",
+    testUsingHikariPool("topology_aware_load_balance", "cloud1.region1.zone1", "cloud1.region1.zone1",
       controlHost, controlPort, numConnections, verbose, interactive);
   }
 }

--- a/examples/topology_aware_load_balance_run.sh
+++ b/examples/topology_aware_load_balance_run.sh
@@ -59,7 +59,8 @@ interact() {
 
 VERBOSE=$1
 INTERACTIVE=$2
-INSTALL_DIR=$3
+DEBUG=$3
+INSTALL_DIR=$4
 
 verbosePrint $VERBOSE "Destroying any exsiting cluster if present..."
 $INSTALL_DIR/bin/yb-ctl destroy  > yb-ctl.log 2>&1
@@ -77,7 +78,7 @@ rm -rf .notify_shell_script
 
 classpath=target/jdbc-yugabytedb-example-0.0.1-SNAPSHOT.jar
 #Starting the Topology Aware Load Balance Example app
-java -cp $classpath com.yugabyte.examples.TopologyAwareLoadBalanceExample $VERBOSE $INTERACTIVE  2>&1  &
+java -cp $classpath com.yugabyte.examples.TopologyAwareLoadBalanceExample $VERBOSE $INTERACTIVE $DEBUG 2>&1  &
 # java -cp $classpath com.yugabyte.examples.TopologyAwareLoadBalance $VERBOSE $INTERACTIVE > jdbc-yugabytedb-example.log 2>&1  &
 
 #storing the pid of the java app

--- a/examples/uniform_load_balance_run.sh
+++ b/examples/uniform_load_balance_run.sh
@@ -59,7 +59,8 @@ interact() {
 
 VERBOSE=$1
 INTERACTIVE=$2
-INSTALL_DIR=$3
+DEBUG=$3
+INSTALL_DIR=$4
 
 verbosePrint $VERBOSE "Destroying any exsiting cluster if present..."
 $INSTALL_DIR/bin/yb-ctl destroy  > yb-ctl.log 2>&1
@@ -77,7 +78,7 @@ rm -rf .notify_shell_script
 
 classpath=target/jdbc-yugabytedb-example-0.0.1-SNAPSHOT.jar
 #Starting the Uniform Load Balance Example app
-java -cp $classpath com.yugabyte.examples.UniformLoadBalanceExample $VERBOSE $INTERACTIVE  2>&1  &
+java -cp $classpath com.yugabyte.examples.UniformLoadBalanceExample $VERBOSE $INTERACTIVE $DEBUG 2>&1  &
 # java -cp $classpath com.yugabyte.examples.UniformLoadBalance $VERBOSE $INTERACTIVE > jdbc-yugabytedb-example.log 2>&1  &
 
 

--- a/jdbc-yugabytedb/src/main/java/com/yugabyte/ysql/TopologyAwareLoadBalancer.java
+++ b/jdbc-yugabytedb/src/main/java/com/yugabyte/ysql/TopologyAwareLoadBalancer.java
@@ -11,42 +11,39 @@ import java.util.logging.Level;
 
 public class TopologyAwareLoadBalancer extends ClusterAwareLoadBalancer {
   private final String placements;
-  private final Map<String, Set<String>> allowedPlacements;
+  private final Set<CloudPlacement> allowedPlacements;
 
   public TopologyAwareLoadBalancer(String placementvalues) {
     placements = placementvalues;
-    allowedPlacements = new HashMap<>();
-    populatePlacementMap();
+    allowedPlacements = new HashSet<>();
+    populatePlacementSet();
   }
 
   protected String loadBalancingNodes() {
     return placements;
   }
 
-  private void populatePlacementMap() {
+  private void populatePlacementSet() {
     String[] placementstrings = placements.split(",");
     for (String pl : placementstrings) {
-      String[] regionandzone = pl.split("\\.");
-      if (regionandzone.length == 1) {
-        // all zones are allowed. Empty hash set means all zones
-        allowedPlacements.put(regionandzone[0], new HashSet<>());
-      } else {
-        Set<String> set = allowedPlacements.get(regionandzone[0]);
-        if (set != null && !set.isEmpty()) {
-          set.add(regionandzone[1]);
-        } else if (set == null) {
-          HashSet<String> zoneset = new HashSet<>();
-          zoneset.add(regionandzone[1]);
-          allowedPlacements.put(regionandzone[0], zoneset);
-        }
+      String[] placementParts = pl.split("\\.");
+      if (placementParts.length != 3) {
+        // Log a warning and return.
+        LOGGER.log(Level.WARNING, getLoadBalancerType() + ": " +
+          "Ignoring malformed topology-key property value: " + pl);
+        continue;
       }
+      CloudPlacement cp = new CloudPlacement(
+        placementParts[0], placementParts[1], placementParts[2]);
+      LOGGER.log(Level.FINE, getLoadBalancerType() + ": Adding placement " + cp + " to allowed list");
+      allowedPlacements.add(cp);
     }
   }
 
   @Override
   protected ArrayList<String> getCurrentServers(Connection conn) throws SQLException {
     Statement st = conn.createStatement();
-    LOGGER.log(Level.FINE, "Getting the list of servers in: " + placements);
+    LOGGER.log(Level.FINE, getLoadBalancerType() + ": Getting the list of servers in: " + placements);
     ResultSet rs = st.executeQuery(ClusterAwareLoadBalancer.GET_SERVERS_QUERY);
     ArrayList<String> currentPrivateIps = new ArrayList<>();
     ArrayList<String> currentPublicIps = new ArrayList<>();
@@ -55,22 +52,66 @@ public class TopologyAwareLoadBalancer extends ClusterAwareLoadBalancer {
     while (rs.next()) {
       String host = rs.getString("host");
       String publicIp = rs.getString("public_ip");
+      String cloud = rs.getString("cloud");
       String region = rs.getString("region");
       String zone = rs.getString("zone");
       String port = rs.getString("port");
       hostPortMap.put(host, port);
       hostPortMap_public.put(publicIp, port);
-      Set<String> zones = allowedPlacements.get(region);
       if (hostConnectedTo.equals(host)) {
         useHostColumn = Boolean.TRUE;
       } else if (hostConnectedTo.equals(publicIp)) {
         useHostColumn = Boolean.FALSE;
       }
-      if (zones != null && (zones.isEmpty() || zones.contains(zone))) {
+      CloudPlacement cp = new CloudPlacement(cloud, region, zone);
+      if (allowedPlacements.contains(cp)) {
+        LOGGER.log(Level.FINE, getLoadBalancerType() + ": allowedPlacements set: " + allowedPlacements +
+          " returned contains true for cp: " + cp);
         currentPrivateIps.add(host);
         currentPublicIps.add(publicIp);
+      } else {
+        LOGGER.log(Level.FINE, getLoadBalancerType() + ": allowedPlacements set: " + allowedPlacements +
+          " returned contains false for cp: " + cp);
+
       }
     }
     return getPrivateOrPublicServers(useHostColumn, currentPrivateIps, currentPublicIps);
+  }
+
+  protected String getLoadBalancerType() {
+    return "TopologyAwareLoadBalancer";
+  }
+
+  static class CloudPlacement {
+    private final String cloud;
+    private final String region;
+    private final String zone;
+
+    CloudPlacement(String cloud, String region, String zone) {
+      this.cloud = cloud;
+      this.region = region;
+      this.zone = zone;
+    }
+
+    public int hashCode() {
+      return cloud.hashCode() ^ region.hashCode() ^ zone.hashCode();
+    }
+
+    public boolean equals(Object other) {
+      boolean equal = false;
+      LOGGER.log(Level.FINE, "equals called for this: " + this + " and other = " + other);
+      if (other instanceof CloudPlacement) {
+        CloudPlacement o = (CloudPlacement) other;
+        equal = this.cloud.equalsIgnoreCase(o.cloud) &&
+          this.region.equalsIgnoreCase(o.region) &&
+          this.zone.equalsIgnoreCase(o.zone);
+      }
+      LOGGER.log(Level.FINE, "equals returning: " + equal);
+      return equal;
+    }
+
+    public String toString() {
+      return "Placement: " + cloud + "." + region + "." + zone;
+    }
   }
 }


### PR DESCRIPTION
- Include 'cloud' part of the placement as well in 'topology-keys'
property value
- Exception handling improvements while getting a balanced connection when refreshing 'server list'.
- Add 'debug' parameter to examples.
- Add more debug level logs to help troubleshooting.

### All Submissions:

* [✅] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [✅] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [✅] Does your submission pass tests?
2. [✅] Does mvn checkstyle:check pass ?
3. [✅] Have you added your new test classes to an existing test suite?

### Changes to Existing Features:

* [✅] Does this break existing behaviour? If so please explain.
   The value of property 'topology-keys' has to contain 'cloud' part also. App using previous version of the driver will have to change in how they specify topology-key value. Previously it was _topology-keys=region1.zone1,region1.zone2_ etc and now it is _topology-keys=cloud1.region1.zone1,cloud1.region1.zone2_
* [✅] Have you added an explanation of what your changes do and why you'd like us to include them?
* [✅] Have you written new tests for your core changes, as applicable?
* [✅] Have you successfully run tests with your changes locally?
